### PR TITLE
[DRAFT] Possible fixes for overflow and scaling issues

### DIFF
--- a/src/Aggor.sol
+++ b/src/Aggor.sol
@@ -257,15 +257,16 @@ contract Aggor is IAggor, Auth, Toll {
             uniPool, uniBasePair, uniQuotePair, uniBaseDec, uniSecondsAgo
         );
 
-        // Fail if value is zero.
-        if (val == 0) {
-            emit UniswapValueZero();
-            return (false, 0);
-        }
-
         // We always scale to 'decimals', up OR down.
         if (uniQuoteDec != decimals) {
             val = LibCalc.scale(val, uniQuoteDec, decimals);
+        }
+
+        // Fail if value is zero.
+        // Note to check after scaling operation!
+        if (val == 0) {
+            emit UniswapValueZero();
+            return (false, 0);
         }
 
         return (true, val);
@@ -315,6 +316,7 @@ contract Aggor is IAggor, Auth, Toll {
         }
 
         // Fail if value is zero.
+        // Note to check after scaling operation!
         if (val == 0) {
             emit ChainlinkValueZero();
             return (false, 0);

--- a/src/libs/LibCalc.sol
+++ b/src/libs/LibCalc.sol
@@ -19,9 +19,9 @@ library LibCalc {
             : pscale - (((uint(a) * 1e18) / uint(b)) * pscale / 1e18);
     }
 
-    /// @dev Computes the numerical distance between two numbers. No overflow
-    ///      worries here.
+    /// @dev Computes the numerical distance between two numbers.
     function distance(uint a, uint b) internal pure returns (uint) {
+        // Unchecked as subtractions are guaranteed to not underflow.
         unchecked {
             return (a > b) ? a - b : b - a;
         }
@@ -35,8 +35,11 @@ library LibCalc {
         pure
         returns (uint)
     {
-        require(n > 0 && dec > 0 && destDec > 0);
+        if (n == 0) return 0;
+
+        require(dec > 0 && destDec > 0);
         require(n > dec && n > destDec);
+
         return destDec > dec
             ? n * (10 ** (destDec - dec)) // Scale up
             : n / (10 ** (dec - destDec)); // Scale down

--- a/src/libs/LibUniswapOracles.sol
+++ b/src/libs/LibUniswapOracles.sol
@@ -8,6 +8,8 @@ import "uniswap/v3-periphery/contracts/libraries/OracleLibrary.sol";
  * @notice Library Uniswap oracle related functionality.
  */
 library LibUniswapOracles {
+    uint internal constant MAX_UNI_BASE_DEC = 38;
+
     /// @notice Read the TWAP derived price from a Uniswap oracle.
     /// @dev The Uniswap pool address + pair addresses can be discovered at
     ///      https://app.uniswap.org/#/swap
@@ -23,6 +25,9 @@ library LibUniswapOracles {
         uint8 uniBaseDec,
         uint32 secondsAgo
     ) internal view returns (uint) {
+        // Note that 10**(MAX_UNI_BASE_DEC + 1) would overflow type uint128.
+        require(uniBaseDec <= MAX_UNI_BASE_DEC);
+
         (int24 tick,) = OracleLibrary.consult(address(uniPool), secondsAgo);
 
         // Calculate exactly 1 unit of the base pair for quote


### PR DESCRIPTION
There are two potential issues in Aggor:
1. The `LibUniswapOracles::readOracle` function may have overflow and revert
2. The `Aggor::_tryReadUniswap` function may return zero value, which it is not allowed to do.

This PR offers possible fixes for the issues. However, both can be solved differently too.

Created this PR as **DRAFT** to start a discussion.